### PR TITLE
Write file in binary mode

### DIFF
--- a/piptools/package_manager.py
+++ b/piptools/package_manager.py
@@ -441,7 +441,7 @@ class PackageManager(BasePackageManager):
         logger.debug('- Downloading package from %s' % (url,))
         with logger.indent():
             _, content = get_file_content(url, link, session=self._session)
-            with open(destination, 'w') as f:
+            with open(destination, 'wb') as f:
                 f.write(content)
 
     def unpack_archive(self, path, target_directory):


### PR DESCRIPTION
'w' fails under Windows, trying to safe a zipped file in text mode
